### PR TITLE
Switch to env variables for DB url - NO MERGE CONFLICTS!

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -7,7 +7,14 @@ from sqlalchemy.orm import relationship, backref
 
 """ DO NOT COMMIT CHANGES TO THIS FILE!! """
 
-engine = create_engine('mysql+pymysql://casey:crystal@127.0.0.1:3306/youtubelib', convert_unicode=True, echo=False)
+if 'CLEARDB_DATABASE_URL' in os.environ and os.environ['CLEARDB_DATABASE_URL']:
+    db_url = os.environ['CLEARDB_DATABASE_URL']
+elif 'MYSQL_DATABASE_URL' in os.environ and os.environ['MYSQL_DATABASE_URL']:
+    db_url = os.environ['MYSQL_DATABASE_URL']
+else:
+    db_url = 'mysql+pymysql://root:@127.0.0.1:3306/youtubelib'
+
+engine = create_engine(db_url, convert_unicode=True, echo=False)
 
 Base = declarative_base()
 Base.metadata.reflect(engine)

--- a/app/models.py
+++ b/app/models.py
@@ -4,6 +4,7 @@
 from sqlalchemy import create_engine
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import relationship, backref 
+import os
 
 """ DO NOT COMMIT CHANGES TO THIS FILE!! """
 


### PR DESCRIPTION
# What

Read database url from environment variable
# Why

When running the app on heroku, the database url will be passed in via environment variable
# What should I do??????

If you are using a custom username / password for your local database, add the following to your ~/.bash_profile
EXPORT MYSQL_DATABASE_URL="mysql+pymysql://YOUR_USERNAME:YOUR_PASSWORD@127.0.0.1:3306/youtubelib"
# Okay, really, why??

This will let us all use custom usernames/passwords for our local databases!
# How do I test this?

Make the change to your .bash_profile, and then start the app in a new terminal tab/window
Everything should be the same!
