### PR TITLE
replaces xml escaped quotes with quotes before posting to db

### DIFF
--- a/app/static/js/play.js
+++ b/app/static/js/play.js
@@ -133,13 +133,13 @@ function playNextVidInList(){
 //records play at top of page
 function savePlay(event, end = false) {
 	title = event.target.b.c.title;
-	title = decodeURIComponent(title.toString());
+	title = decodeURIComponent(title.toString()).replace("&apos;", "'").replace('&quot;', '"');
 	youtube_id = event.target.b.c.videoId;
 	youtube_id = youtube_id.toString();
 	channel_id = event.target.b.c.channel_id;
 	channel_id = channel_id.toString();
 	description = event.target.b.c.description;
-	description = decodeURIComponent(description.toString());
+	description = decodeURIComponent(description.toString()).replace("&apos;", "'").replace('&quot;', '"');
 
 	console.log("channel_id and description test /" );
 	console.log(channel_id);


### PR DESCRIPTION
# What

replaces xml escaped quotes with quotes before posting to db
# Why

keep db clean
# Test
- play a video with quotes in the title that's not yet in your db
- make sure it's stored in db without "&apos;" or "&quot;"
