### PR TITLE
pulls full album out and years out of titles

### DIFF
--- a/app/myfunctions.py
+++ b/app/myfunctions.py
@@ -1,0 +1,32 @@
+def sortnumbers(num_list):
+
+    class sorted_numbers:
+      def __init__(self, low=None, average=None, high=None):
+          self.low = low
+          self.average = average
+          self.high = high
+
+      def __getitem__ (self, low, average, high):
+          return self.index
+          return self.low
+          return self.average 
+          return self.high 
+
+    sortednum = sorted_numbers  
+    total = 0;
+    i = 0
+    sortednum.low = 100^(10000000000000000)
+    sortednum.high = -100^(10000000000000000)
+    for num in num_list:
+      total = total + int(num)
+      if int(num) < sortednum.low:
+        sortednum.low = int(num)
+      if int(num) > sortednum.high:
+        sortednum.high = int(num)
+        i = i+1;
+    if i>0:
+      sortednum.average = total/i
+    else:
+      sortednum.average = total
+
+    return sortednum;

--- a/app/static/js/lastfm.js
+++ b/app/static/js/lastfm.js
@@ -20,14 +20,51 @@ function lastFMGetSimilarArtists(artistName, callBack) {
                 similarartiststring.push('undefined,0.00');
             }
             callBack(similarartiststring);
+            //return similarartiststring;
         }
     });
 }
-function lastFMGetAlbumsByArtist(artistName, callBack) {
-    var albums = [];
+//get album and track number and year
+//method=track.getInfo&api_key=YOUR_API_KEY&artist=cher&track=believe&format=json
+
+function lastFMGetGenresByTrack(title, artistName) {
+    var tags = [];
+    //var track_num is null;
+    
     results = $.ajax({
         url: "http://ws.audioscrobbler.com/2.0/",
-        data: "method=artist.gettopalbums&" +
+        data: "method=track.getInfo" +
+            "&api_key=175f6031e4788e29a9ff3961219ffc06" +
+            "&artist=" +
+            artistName +
+            "&track=" +
+            title +
+            "&format=json",
+        dataType: "jsonp",
+        success: function (data) {
+            console.log(data);
+            if(data.track.toptags != null){
+                $.each(data.track.toptags.tag, function(index=100, item){
+                    console.log(item.name);
+                    
+                    tags.push(item.name);
+                });
+            }else{
+                tags.push('music');
+            }
+            //callBack(tags);
+            return tags;
+        }
+    });
+}
+//change to get album by track
+/*
+function lastFMGetGenresByTrack(artistName) {
+    var tags = [];
+    //console.log("artistName: ", artistName);
+    results = $.ajax({
+        url: "http://ws.audioscrobbler.com/2.0/",
+        data: "method=artist.getsimilar&" +
             "artist=" +
             artistName +
             "&" +
@@ -35,18 +72,23 @@ function lastFMGetAlbumsByArtist(artistName, callBack) {
             "format=json",
         dataType: "jsonp",
         success: function (data) {
-            //console.log(data);
-            /*
-            $.each(data.similarartists.artist, function(index=100, item){
-                console.log(item);
-                albums.push(item.name);
-            });
-            callBack(albums);
-            */
+            if(data.similarartists != null){
+                $.each(data.track.toptags, function(index=100, item){
+                    item.tag
+                    tags.push(item.tag);
+                });
+            }else{
+                tags.push('music');
+            }
+            callBack(tags);
+            return tags;
         }
     });
-}
-function lastFMGetAlbumByTrack(title, artistName, callBack) {
+}*/
+
+//if we don't already have it
+function lastFMGetAlbumYear(title, artistName, callBack) {
+
     var track_name ="";
     //var track_num is null;
     
@@ -69,12 +111,20 @@ function lastFMGetAlbumByTrack(title, artistName, callBack) {
             });
             callBack(albums);
             */
+            //return albums;
         }
     });
-}
-////2.0/?method=track.getInfo&api_key=YOUR_API_KEY&artist=cher&track=believe&format=json
+}/*
+function getLastFMData(artistName,Title,Album, callback){
 
-//takes artist and gets album names
 
-//takes title and artist and gets album name and track numer
+    callback(albums, similarartiststring, )
+}*/
+    
+//method=track.gettoptags&artist=radiohead&track=paranoid+android&api_key=YOUR... *get track genres
+//method=track.getInfo&api_key=YOUR_API_KEY&artist=cher&track=believe&format=json *get track number and maybe year
+//method=album.getinfo&api_key=YOUR_API_KEY&artist=Cher&album=Believe&format=json *get album year and genres
+
+
+
 

--- a/app/static/js/lastfm.js
+++ b/app/static/js/lastfm.js
@@ -47,28 +47,75 @@ function lastFMGetGenresByTrack(title, artistName, callBack) {
             "&format=json",
         dataType: "jsonp",
         success: function (data) {
-            console.log(data);
             if(data.track.toptags.tag.length > 0){
-                console.log("data not null");
                 $.each(data.track.toptags.tag, function(index=100, item){
                     tags.push(item.name);
                 });
-            }else{
-                console.log("music!");
+            }/*else{
                 tags.push('music');
-            }
-            console.log("js tags");
-            console.log(tags);
+            }*/
             callBack(tags);
             
         }
     });
 }
-
+//method=album.getinfo&api_key=YOUR_API_KEY&artist=Cher&album=Believe&format=json
+//method=album.gettoptags&artist=radiohead&album=the%20bends&api_key=YOUR_API_...
+function lastFMGetGenresByAlbum(album, artistName, callBack) {
+    var tags = []; 
+    results = $.ajax({
+        url: "http://ws.audioscrobbler.com/2.0/",
+        data: "method=album.getinfo" +
+            "&artist=" +
+            artistName +
+            "&album=" +
+            album +
+            "&api_key=175f6031e4788e29a9ff3961219ffc06" +
+            "&format=json",
+        dataType: "jsonp",
+        success: function (data) {
+            if(data.album.tags.tag.length > 0){
+                console.log("data not null");
+                $.each(data.album.tags.tag, function(index=100, item){
+                    tags.push(item.name);
+                });
+            }/*else{
+                tags.push('music');
+            }*/
+            console.log(tags);
+            callBack(tags); 
+        }
+    });
+}
+function lastFMGetGenresByArtist(artistName, callBack) {
+    var tags = []; 
+    results = $.ajax({
+        url: "http://ws.audioscrobbler.com/2.0/",
+        data: "method=artist.getinfo" +
+            "&artist=" +
+            artistName +
+            "&api_key=175f6031e4788e29a9ff3961219ffc06" +
+            "&format=json",
+        dataType: "jsonp",
+        success: function (data) {
+            console.log("artist data");
+            console.log(data);
+            if(data.artist.tags.tag.length > 0){
+                console.log("data not null");
+                $.each(data.artist.tags.tag, function(index=100, item){
+                    tags.push(item.name);
+                });
+            }else{
+                tags.push('music');
+            }
+            console.log(tags);
+            callBack(tags); 
+        }
+    });
+}
 function lastFMGetBioByArtist(artistName, callBack) {
     var bio = "";
     //var track_num is null;
-    console.log(artistName);
     results = $.ajax({
         url: "http://ws.audioscrobbler.com/2.0/",
         data: "method=artist.getInfo" +
@@ -78,8 +125,6 @@ function lastFMGetBioByArtist(artistName, callBack) {
             "&format=json",
         dataType: "jsonp",
         success: function (data) {
-            
-            console.log(data);
             if(data.artist.bio.content){
                 bio = data.artist.bio.content
             }

--- a/app/static/js/lastfm.js
+++ b/app/static/js/lastfm.js
@@ -1,3 +1,10 @@
+// Class to hold Last.fm API track
+function albumInfo(album, trackNumber, year) {
+    this.album = album;
+    this.trackNumber = trackNumber;
+    this.year = year;
+}
+
 function lastFMGetSimilarArtists(artistName, callBack) {
     var similarartiststring = [];
     //console.log("artistName: ", artistName);
@@ -24,10 +31,8 @@ function lastFMGetSimilarArtists(artistName, callBack) {
         }
     });
 }
-//get album and track number and year
-//method=track.getInfo&api_key=YOUR_API_KEY&artist=cher&track=believe&format=json
 
-function lastFMGetGenresByTrack(title, artistName) {
+function lastFMGetGenresByTrack(title, artistName, callBack) {
     var tags = [];
     //var track_num is null;
     
@@ -43,20 +48,91 @@ function lastFMGetGenresByTrack(title, artistName) {
         dataType: "jsonp",
         success: function (data) {
             console.log(data);
-            if(data.track.toptags != null){
+            if(data.track.toptags.tag.length > 0){
+                console.log("data not null");
                 $.each(data.track.toptags.tag, function(index=100, item){
-                    console.log(item.name);
-                    
                     tags.push(item.name);
                 });
             }else{
+                console.log("music!");
                 tags.push('music');
             }
-            //callBack(tags);
-            return tags;
+            console.log("js tags");
+            console.log(tags);
+            callBack(tags);
+            
         }
     });
 }
+//method=artist.getinfo&artist=Cher&api_key=YOUR_API_KEY&format=json
+function lastFMGetCities(artistName) {
+    //var track_num is null;
+    console.log(artistName);
+    results = $.ajax({
+        url: "http://ws.audioscrobbler.com/2.0/",
+        data: "method=artist.getInfo" +
+            "&api_key=175f6031e4788e29a9ff3961219ffc06" +
+            "&artist=" +
+            artistName +
+            "&format=json",
+        dataType: "jsonp",
+        success: function (data) {
+            console.log(data);
+            /*
+            if(data.track.toptags.tag.length > 0){
+                console.log("data not null");
+                $.each(data.track.toptags.tag, function(index=100, item){
+                    tags.push(item.name);
+                });
+            }else{
+                console.log("music!");
+                tags.push('music');
+            }
+            console.log("js tags");
+            console.log(tags);*/
+            //callBack(tags);
+            
+        }
+    });
+}
+
+/*
+function lastFMGetTrackNum(artistName, albumName, trackName) {
+    
+    //var track_num is null;
+    
+    results = $.ajax({
+        url: "http://ws.audioscrobbler.com/2.0/",
+        data: "method=album.getInfo" +
+            "&api_key=175f6031e4788e29a9ff3961219ffc06" +
+            "&artist=" +
+            artistName +
+            "&album=" +
+            albumName +
+            "&format=json",
+        dataType: "jsonp",
+        success: function (data) {
+            var trackNum = null;
+            console.log(data);
+            if(data.track.toptags != null){
+                $.each(data.album.tracks.track, function(index=100, item){
+                    if (item.name == trackName) {
+                        trackNum = index + 1;
+                    }
+                
+                });
+            }
+            //callBack(tags);
+            return trackNum;
+        }
+    });
+}*/
+
+
+//get album and track number and year
+//method=track.getInfo&api_key=YOUR_API_KEY&artist=cher&track=believe&format=json
+
+
 //change to get album by track
 /*
 function lastFMGetGenresByTrack(artistName) {
@@ -87,6 +163,7 @@ function lastFMGetGenresByTrack(artistName) {
 }*/
 
 //if we don't already have it
+/*
 function lastFMGetAlbumYear(title, artistName, callBack) {
 
     var track_name ="";
@@ -104,17 +181,17 @@ function lastFMGetAlbumYear(title, artistName, callBack) {
         dataType: "jsonp",
         success: function (data) {
             //console.log(data);
-            /*
+            
             $.each(data.similarartists.artist, function(index=100, item){
                 console.log(item);
                 albums.push(item.name);
             });
             callBack(albums);
-            */
+            
             //return albums;
         }
     });
-}/*
+}*//*
 function getLastFMData(artistName,Title,Album, callback){
 
 

--- a/app/static/js/lastfm.js
+++ b/app/static/js/lastfm.js
@@ -65,7 +65,8 @@ function lastFMGetGenresByTrack(title, artistName, callBack) {
     });
 }
 //method=artist.getinfo&artist=Cher&api_key=YOUR_API_KEY&format=json
-function lastFMGetCities(artistName) {
+function lastFMGetBioByArtist(artistName, callBack) {
+    var bio = "";
     //var track_num is null;
     console.log(artistName);
     results = $.ajax({
@@ -77,20 +78,15 @@ function lastFMGetCities(artistName) {
             "&format=json",
         dataType: "jsonp",
         success: function (data) {
+            
             console.log(data);
-            /*
-            if(data.track.toptags.tag.length > 0){
-                console.log("data not null");
-                $.each(data.track.toptags.tag, function(index=100, item){
-                    tags.push(item.name);
-                });
-            }else{
-                console.log("music!");
-                tags.push('music');
+            if(data.artist.bio.content){
+                bio = data.artist.bio.content
             }
-            console.log("js tags");
-            console.log(tags);*/
-            //callBack(tags);
+            console.log("~~~~~~~~~bio start ~~~~~~~~~~~~");
+            console.log(bio);
+            console.log("~~~~~~~~~bio end ~~~~~~~~~~~~");
+            callBack(bio);
             
         }
     });

--- a/app/static/js/lastfm.js
+++ b/app/static/js/lastfm.js
@@ -64,7 +64,7 @@ function lastFMGetGenresByTrack(title, artistName, callBack) {
         }
     });
 }
-//method=artist.getinfo&artist=Cher&api_key=YOUR_API_KEY&format=json
+
 function lastFMGetBioByArtist(artistName, callBack) {
     var bio = "";
     //var track_num is null;
@@ -83,120 +83,13 @@ function lastFMGetBioByArtist(artistName, callBack) {
             if(data.artist.bio.content){
                 bio = data.artist.bio.content
             }
-            console.log("~~~~~~~~~bio start ~~~~~~~~~~~~");
-            console.log(bio);
-            console.log("~~~~~~~~~bio end ~~~~~~~~~~~~");
             callBack(bio);
             
         }
     });
 }
 
-/*
-function lastFMGetTrackNum(artistName, albumName, trackName) {
-    
-    //var track_num is null;
-    
-    results = $.ajax({
-        url: "http://ws.audioscrobbler.com/2.0/",
-        data: "method=album.getInfo" +
-            "&api_key=175f6031e4788e29a9ff3961219ffc06" +
-            "&artist=" +
-            artistName +
-            "&album=" +
-            albumName +
-            "&format=json",
-        dataType: "jsonp",
-        success: function (data) {
-            var trackNum = null;
-            console.log(data);
-            if(data.track.toptags != null){
-                $.each(data.album.tracks.track, function(index=100, item){
-                    if (item.name == trackName) {
-                        trackNum = index + 1;
-                    }
-                
-                });
-            }
-            //callBack(tags);
-            return trackNum;
-        }
-    });
-}*/
 
-
-//get album and track number and year
-//method=track.getInfo&api_key=YOUR_API_KEY&artist=cher&track=believe&format=json
-
-
-//change to get album by track
-/*
-function lastFMGetGenresByTrack(artistName) {
-    var tags = [];
-    //console.log("artistName: ", artistName);
-    results = $.ajax({
-        url: "http://ws.audioscrobbler.com/2.0/",
-        data: "method=artist.getsimilar&" +
-            "artist=" +
-            artistName +
-            "&" +
-            "api_key=175f6031e4788e29a9ff3961219ffc06&" +
-            "format=json",
-        dataType: "jsonp",
-        success: function (data) {
-            if(data.similarartists != null){
-                $.each(data.track.toptags, function(index=100, item){
-                    item.tag
-                    tags.push(item.tag);
-                });
-            }else{
-                tags.push('music');
-            }
-            callBack(tags);
-            return tags;
-        }
-    });
-}*/
-
-//if we don't already have it
-/*
-function lastFMGetAlbumYear(title, artistName, callBack) {
-
-    var track_name ="";
-    //var track_num is null;
-    
-    results = $.ajax({
-        url: "http://ws.audioscrobbler.com/2.0/",
-        data: "method=track.getInfo" +
-            "&api_key=175f6031e4788e29a9ff3961219ffc06" +
-            "&artist=" +
-            artistName +
-            "&track=" +
-            title +
-            "&format=json",
-        dataType: "jsonp",
-        success: function (data) {
-            //console.log(data);
-            
-            $.each(data.similarartists.artist, function(index=100, item){
-                console.log(item);
-                albums.push(item.name);
-            });
-            callBack(albums);
-            
-            //return albums;
-        }
-    });
-}*//*
-function getLastFMData(artistName,Title,Album, callback){
-
-
-    callback(albums, similarartiststring, )
-}*/
-    
-//method=track.gettoptags&artist=radiohead&track=paranoid+android&api_key=YOUR... *get track genres
-//method=track.getInfo&api_key=YOUR_API_KEY&artist=cher&track=believe&format=json *get track number and maybe year
-//method=album.getinfo&api_key=YOUR_API_KEY&artist=Cher&album=Believe&format=json *get album year and genres
 
 
 

--- a/app/static/js/lastfm.js
+++ b/app/static/js/lastfm.js
@@ -11,10 +11,14 @@ function lastFMGetSimilarArtists(artistName, callBack) {
             "format=json",
         dataType: "jsonp",
         success: function (data) {
-            $.each(data.similarartists.artist, function(index=100, item){
-                item.name.replace(/,/g,' ')
-                similarartiststring.push(item.name+','+item.match);
-            });
+            if(data.similarartists != null){
+                $.each(data.similarartists.artist, function(index=100, item){
+                    item.name.replace(/,/g,' ')
+                    similarartiststring.push(item.name+','+item.match);
+                });
+            }else{
+                similarartiststring.push('undefined,0.00');
+            }
             callBack(similarartiststring);
         }
     });

--- a/app/static/js/lastfm.js
+++ b/app/static/js/lastfm.js
@@ -1,6 +1,6 @@
 function lastFMGetSimilarArtists(artistName, callBack) {
     var similarartiststring = [];
-    console.log("artistName: ", artistName);
+    //console.log("artistName: ", artistName);
     results = $.ajax({
         url: "http://ws.audioscrobbler.com/2.0/",
         data: "method=artist.getsimilar&" +
@@ -12,7 +12,6 @@ function lastFMGetSimilarArtists(artistName, callBack) {
         dataType: "jsonp",
         success: function (data) {
             $.each(data.similarartists.artist, function(index=100, item){
-                console.log(item);
                 item.name.replace(/,/g,' ')
                 similarartiststring.push(item.name+','+item.match);
             });
@@ -20,4 +19,58 @@ function lastFMGetSimilarArtists(artistName, callBack) {
         }
     });
 }
+function lastFMGetAlbumsByArtist(artistName, callBack) {
+    var albums = [];
+    results = $.ajax({
+        url: "http://ws.audioscrobbler.com/2.0/",
+        data: "method=artist.gettopalbums&" +
+            "artist=" +
+            artistName +
+            "&" +
+            "api_key=175f6031e4788e29a9ff3961219ffc06&" +
+            "format=json",
+        dataType: "jsonp",
+        success: function (data) {
+            //console.log(data);
+            /*
+            $.each(data.similarartists.artist, function(index=100, item){
+                console.log(item);
+                albums.push(item.name);
+            });
+            callBack(albums);
+            */
+        }
+    });
+}
+function lastFMGetAlbumByTrack(title, artistName, callBack) {
+    var track_name ="";
+    //var track_num is null;
+    
+    results = $.ajax({
+        url: "http://ws.audioscrobbler.com/2.0/",
+        data: "method=track.getInfo" +
+            "&api_key=175f6031e4788e29a9ff3961219ffc06" +
+            "&artist=" +
+            artistName +
+            "&track=" +
+            title +
+            "&format=json",
+        dataType: "jsonp",
+        success: function (data) {
+            //console.log(data);
+            /*
+            $.each(data.similarartists.artist, function(index=100, item){
+                console.log(item);
+                albums.push(item.name);
+            });
+            callBack(albums);
+            */
+        }
+    });
+}
+////2.0/?method=track.getInfo&api_key=YOUR_API_KEY&artist=cher&track=believe&format=json
+
+//takes artist and gets album names
+
+//takes title and artist and gets album name and track numer
 

--- a/app/static/js/play.js
+++ b/app/static/js/play.js
@@ -142,6 +142,8 @@ function parseArtistTitleYear(youtubeTitle) {
         splitter = '|';
     } else if (youtubeTitle.indexOf('"') > -1) {
         splitter = '"';
+    }else if (youtubeTitle.indexOf('~') > -1) {
+        splitter = '~';
     }else {
         splitter = ':';
     }
@@ -185,6 +187,7 @@ function parseArtistTitleYear(youtubeTitle) {
 	}
 	trackInfo.title = trackInfo.title.replace(/-/g, '');
 	trackInfo.title = trackInfo.title.replace(/:/g, '');
+	trackInfo.title = trackInfo.title.replace(/~/g, '');
 	trackInfo.title = trackInfo.title.replace(/\|/g, '');
 	trackInfo.title = trackInfo.title.replace(/\(.*\)/g, '');
 	trackInfo.title = trackInfo.title.replace(/\[.*\]/g, '');
@@ -233,6 +236,8 @@ function savePlay(event, end = false) {
 	if(end){
 		listened_to_end = 1;
 	}
+	console.log("album");
+	console.log(album);
 	//send data to view.py
 	lastFMGetSimilarArtists(trackInfo.artistName, function(similarartiststring) {
 		$.ajax({

--- a/app/static/js/play.js
+++ b/app/static/js/play.js
@@ -203,12 +203,12 @@ function parseArtistTitleYear(youtubeTitle) {
 	}else{
 		trackInfo.album = "undefined";
 	}
-	
+	/*
 	console.log(trackInfo.title);
 	console.log("track info year");
 	console.log(trackInfo.year);
 	console.log("album");
-	console.log(trackInfo.album);
+	console.log(trackInfo.album);*/
     return trackInfo;
 }
 
@@ -216,6 +216,8 @@ function parseArtistTitleYear(youtubeTitle) {
 function savePlay(event, end = false) {
 
 	youtube_id = event.target.b.c.videoId;
+	console.log("prepost youtube id");
+	console.log(youtube_id);
 	youtube_id = youtube_id.toString();
 	channel_id = event.target.b.c.channel_id;
 	channel_id = channel_id.toString();
@@ -236,8 +238,8 @@ function savePlay(event, end = false) {
 	if(end){
 		listened_to_end = 1;
 	}
-	console.log("album");
-	console.log(album);
+	console.log("first post dashes?");
+	console.log(youtube_id);
 	//send data to view.py
 	lastFMGetSimilarArtists(trackInfo.artistName, function(similarartiststring) {
 		$.ajax({
@@ -249,12 +251,36 @@ function savePlay(event, end = false) {
 			$("#record_plays").append(youtube_title).append("<br>");
 		}
 	});
+	console.log("dashes in youtube_id?");
+	console.log(youtube_id)
+	if (album == "undefined"){
+		console.log("post genres");
+		lastFMGetGenresByTrack(title, artist, function(tags) {
+			console.log(youtube_id);
+			$.ajax({
+				type: "POST",
+		    	url: '/postgenres',
+		    	data: {youtube_id: youtube_id, genres: JSON.stringify(tags)}
+		    });
+		});
+	}
+	console.log("last fm get cities~~~~~~~~~~");
+	lastFMGetCities(artist);
+	console.log("~~~~~~~~~~~~~~~~~~~~~~~~~~~~");
+	/*
+	console.log("~~~~~album before if else ~~~~~~~~~");
+	console.log(album);
 	if (album == "undefined"){
 		console.log("lastFMGetAlbumByTrack");
 		genres = lastFMGetGenresByTrack(title, artist);
 		console.log("genres");
 		console.log(genres);
 	}
+	else {
+		console.log("lastFMGetTrackNum");
+		info = lastFMGetTrackNum(artist, album, title);
+		console.log(info);
+	}*/
 
 }
 

--- a/app/static/js/play.js
+++ b/app/static/js/play.js
@@ -249,6 +249,13 @@ function savePlay(event, end = false) {
 			$("#record_plays").append(youtube_title).append("<br>");
 		}
 	});
+	if (album == "undefined"){
+		console.log("lastFMGetAlbumByTrack");
+		genres = lastFMGetGenresByTrack(title, artist);
+		console.log("genres");
+		console.log(genres);
+	}
+
 }
 
 //get and render related videos

--- a/app/static/js/play.js
+++ b/app/static/js/play.js
@@ -265,7 +265,16 @@ function savePlay(event, end = false) {
 		});
 	}
 	console.log("last fm get cities~~~~~~~~~~");
-	lastFMGetCities(artist);
+	
+
+	lastFMGetBioByArtist(artist, function(bio) {
+			$.ajax({
+				type: "POST",
+		    	url: '/postartistinfo',
+		    	data: {artist: artist, bio: bio}
+		    });
+	});
+
 	console.log("~~~~~~~~~~~~~~~~~~~~~~~~~~~~");
 	/*
 	console.log("~~~~~album before if else ~~~~~~~~~");

--- a/app/views.py
+++ b/app/views.py
@@ -111,6 +111,10 @@ def postlistens():
     year = None
   else: 
     year = request.form["year"] 
+  if(request.form["album"] != "undefined"):
+    track_num = 0
+  else:
+    track_num = None
 
   
   artist_id = updateartist(str(request.form["artist"]))
@@ -124,6 +128,7 @@ def postlistens():
                   album_id = album_id,
                   channel_id = str(request.form["channel_id"]),
                   description = str(request.form["description"]),
+                  track_num = track_num,
                   release_date = year)
     session.add(new_video)
     session.commit()
@@ -193,7 +198,7 @@ def getlistensdata(search_start_date, search_end_date):
    , artists.artist_name as artist
    , cities.name
    , albums.name as album
-   , albums.track_num
+   , videos.track_num
    , artists.id as artist_id
    , albums.id as album_id
    FROM listens
@@ -322,7 +327,7 @@ def getlibrary(user_id):
    , artists.artist_name as artist
    , cities.name
    , albums.name as album
-   , albums.track_num
+   , videos.track_num
    , artists.id as artist_id
    , albums.id as album_id
    FROM saved_vids

--- a/app/views.py
+++ b/app/views.py
@@ -231,22 +231,7 @@ def postartistinfo():
                     q.end_year = str(years.high)+'-01-01'
                   session.add(q)
                   session.commit()
-              print "~~~~~~~years low and high set~~~~~~~~~~~"
-              """
-              session.rollback()
-              q = session.query(models.Artist)
-              q = q.filter(models.Artist.id==artist_in_db.id)
-              record = q.one()
-              record.start_year = str(years.low)+'-01-01'
-              thisyear = int(datetime.datetime.now())
-              print str(thisyear)
-              print str(years.hight)
-              print "diff = "+str(thisyear - int(years.high))
-              #set end date if inactive for 10+ yr
-              if thisyear - int(years.high) > 10:
-                record.end_year = str(years.high)+'-01-01'
-              session.flush()
-              """
+
       #if artist doesn't have city, store city
       if artist_in_db.city_id == 2:
         cities_results = getCities(select = " id, city_or_state")
@@ -260,13 +245,7 @@ def postartistinfo():
                   q.city_id= str(city.id)
                   session.add(q)
                   session.commit()
-              """
-              q = session.query(models.Artist)
-              q = q.filter(models.Artist.id==artist_in_db.id)
-              record = q.one()
-              record.city_id = int(city.id)
-              session.flush()
-              """
+
     else:
       print "no bio"
 
@@ -295,7 +274,7 @@ def getlistensdata(search_start_date, search_end_date):
    , videos.music
    , videos.release_date
    , artists.artist_name as artist
-   , cities.name
+   , cities.city_or_state
    , albums.name as album
    , videos.track_num
    , artists.id as artist_id
@@ -450,7 +429,7 @@ def getlibrary(user_id):
    , videos.music
    , videos.release_date
    , artists.artist_name as artist
-   , cities.name
+   , cities.city_or_state
    , albums.name as album
    , videos.track_num
    , artists.id as artist_id

--- a/app/views.py
+++ b/app/views.py
@@ -94,47 +94,30 @@ def login():
 # post listens from play page
 @app.route('/postlistens', methods=['POST'])
 def postlistens():
-  #split youtube title into title and artist
-  youtube_title = request.form["youtube_title"]
-  if '-' in youtube_title:
-    splitter = '-'
-  else: splitter = ':'
-  split_youtube_title = youtube_title.split(splitter, 1)
-  artist_artist_name = split_youtube_title[0]
-  artist_artist_name = artist_artist_name.strip()
-  videos_title = split_youtube_title[1]
-  years = re.findall(r'\d{4}', videos_title)
-  if years:
-    year = str(years[0])
-  else: 
-    year = ''
-  videos_title = re.sub('\(.*\)', '', videos_title)
-  videos_title = videos_title.replace('full album', '')
-  videos_title = videos_title.replace('Full Album', '')
-  videos_title = videos_title.replace('- full album', '')
-  videos_title = videos_title.replace('- Full Album', '')
-  videos_title = videos_title.replace(year, '')
-  videos_title = videos_title.replace('-', '').strip()
 
-  print "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
-  print "title: "+videos_title+" year:"+year
-  print "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
-  artist_id = updateartist(artist_artist_name)
   #add videos and listens
+  """
+  youtube_title = str(request.form["youtube_title"])
+  title = str(request.form["title"])
+  artist_name = str(request.form["artist"])
+  album_name = str(request.form["album"])
+  """
+  artist_id = updateartist(str(request.form["artist"]))
   session.rollback()
   video_in_db = session.query(models.Video).filter_by(youtube_id = request.form["youtube_id"]).first()
   if not video_in_db:
-    new_video = models.Video(youtube_id=request.form["youtube_id"],
-                  youtube_title=request.form["youtube_title"],
-                  title = videos_title,
+    new_video = models.Video(youtube_id=str(request.form["youtube_id"]),
+                  youtube_title=str(request.form["youtube_title"]),
+                  title = str(request.form["title"]),
                   artist_id = artist_id,
-                  channel_id = request.form["channel_id"],
-                  description = request.form["description"])
+                  channel_id = str(request.form["channel_id"]),
+                  description = str(request.form["description"]),
+                  release_date = str(request.form["year"]))
     session.add(new_video)
     session.commit()
   #post listen
   new_listen = models.Listen(user_id=request.form["user_id"],
-                youtube_id=request.form["youtube_id"],
+                youtube_id=str(request.form["youtube_id"]),
                 listened_to_end=request.form["listened_to_end"])
   session.add(new_listen)
   session.commit()
@@ -148,7 +131,7 @@ def postlistens():
   for artist in artists_table:
     artist_table_list.append(artist[5].lower())
   #similar_artists_list is a list of all the artists that are 
-  #listed as similar to artist_artist_name artist (currently playing artist) in our db
+  #listed as similar to artist_name artist (currently playing artist) in our db
   similar_artists = getsimilarartistsbyartist(artist_id)
   if similar_artists:
     for artist in similar_artists:
@@ -159,11 +142,8 @@ def postlistens():
   for lastfm_artist in lastfm_similar_artists_list:
     artistandmatch = lastfm_artist.split(',')
     #add if last fm similar artist isn't in artists table
-    print "~~~~~~~~~~~~~~~~~~~~~"
-    print artistandmatch
-    print "~~~~~~~~~~~~~~~~~~~~~"
     artist = artistandmatch[0]
-    match = artistandmatch[1] #bug: lastfm.js not replacing all "," with spaces so sometimes match will be an artist name instead of an integer
+    match = artistandmatch[1]
 
     if artist.lower() not in artist_table_list:
       session.rollback()

--- a/app/views.py
+++ b/app/views.py
@@ -102,6 +102,17 @@ def postlistens():
   artist_name = str(request.form["artist"])
   album_name = str(request.form["album"])
   """
+  if (request.form["album"] != "undefined"):
+    print "album not undefined"
+    album_id = updatealbum(request.form["album"])
+  else:
+    album_id = 2
+  if(request.form["year"] == "1900-01-01"):
+    year = None
+  else: 
+    year = request.form["year"] 
+
+  
   artist_id = updateartist(str(request.form["artist"]))
   session.rollback()
   video_in_db = session.query(models.Video).filter_by(youtube_id = request.form["youtube_id"]).first()
@@ -110,9 +121,10 @@ def postlistens():
                   youtube_title=str(request.form["youtube_title"]),
                   title = str(request.form["title"]),
                   artist_id = artist_id,
+                  album_id = album_id,
                   channel_id = str(request.form["channel_id"]),
                   description = str(request.form["description"]),
-                  release_date = str(request.form["year"]))
+                  release_date = year)
     session.add(new_video)
     session.commit()
   #post listen
@@ -278,6 +290,23 @@ def updateartist(artist_artist_name):
     artist_id = int(new_artist_id.id)
 
   return artist_id
+
+def updatealbum(album_name):
+  #if artist name exists in db but it is not already tied to video, update videos table row with new artist_id
+  session.rollback()
+  album_by_name = session.query(models.Album).filter_by(name = album_name).first()
+  if album_by_name:
+    album_id = album_by_name.id
+  #if artist name doesn't exist in db, add new row to artists table
+  else:
+    session.rollback()
+    new_album = models.Album(name = album_name)
+    session.add(new_album)
+    session.commit()
+    new_album_id = session.query(models.Album).filter_by(name = album_name).first()
+    album_id = int(new_album_id.id)
+
+  return album_id
 
 #pulls data for library page
 def getlibrary(user_id):

--- a/app/views.py
+++ b/app/views.py
@@ -208,7 +208,6 @@ def postartistinfo():
       if not artist_in_db.start_year:
         potentialdates = re.findall('\d{4}', bio)
         if potentialdates:
-
           for date in potentialdates:
             if int(date)>1500 and int(date)<=thisyear:
               mentionedyears.append(int(date))
@@ -250,17 +249,24 @@ def postartistinfo():
               """
       #if artist doesn't have city, store city
       if artist_in_db.city_id == 2:
-        cities_results = getCities(select = " id, state, city")
+        cities_results = getCities(select = " id, city_or_state")
         for city in cities_results:
-            print str(city.state)+str(city.city)
-            if (str(city.state) in bio) or (str(city.city) in bio):
-              print str(city.state)+" in bio"
+            print str(city.city_or_state)
+            if str(city.city_or_state) in bio:
+              print str(city.city_or_state)+" in bio"
               session.rollback()
+              q = session.query(models.Artist).filter_by(id=artist_in_db.id).one()
+              if q != []:
+                  q.city_id= str(city.id)
+                  session.add(q)
+                  session.commit()
+              """
               q = session.query(models.Artist)
               q = q.filter(models.Artist.id==artist_in_db.id)
               record = q.one()
               record.city_id = int(city.id)
               session.flush()
+              """
     else:
       print "no bio"
 


### PR DESCRIPTION
# What

pulls the following from last fm: genre (tags in last fm), start year, end year, city
# Why

so we have more metadata to play with
# Test
- update database
- listen to a few tracks on youtube (not full albums)
- check artists and vids_genres table to see if data was posted.
- merge!
# SQL

```
ALTER TABLE videos
ADD COLUMN track_num int(5) DEFAULT NULL;

ALTER TABLE albums
DROP COLUMN track_num;

ALTER TABLE cities
ADD COLUMN city_or_state varchar(100) DEFAULT NULL;

UPDATE cities
SET city_or_state = name;

ALTER TABLE cities
DROP COLUMN `name`;


```
# known bugs:
- lastfm.js not replacing all "," with spaces when it makes
  the artistandmatch string so sometimes match will be an artist name
  instead of an integer
- not sure why but sometimes youtube_id and genre don't get insterted into the vids_genres table correctly and since they are both foreign keys, it causes the insert to fail so the track's genres aren't stored.
