### PR TITLE
Migrate from ClearDB to AWS

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -1,4 +1,4 @@
-	#!/usr/bin/python
+#!/usr/bin/python
 # -*- mode: python -*-
 
 from sqlalchemy import create_engine

--- a/app/models.py
+++ b/app/models.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+	#!/usr/bin/python
 # -*- mode: python -*-
 
 from sqlalchemy import create_engine
@@ -22,10 +22,6 @@ except NameError:
 else:
 	engine.dispose()
 	print("~~~~~~~~~~~~~connection closed~~~~~~~~~~~~~~~~~")
-
-if 'CLEARDB_DATABASE_URL' in os.environ and os.environ['CLEARDB_DATABASE_URL']:
-    db_url = os.environ['CLEARDB_DATABASE_URL']
-    db_url = db_url.replace("reconnect=true", "")
 
 elif 'MYSQL_DATABASE_URL' in os.environ and os.environ['MYSQL_DATABASE_URL']:
     db_url = os.environ['MYSQL_DATABASE_URL']


### PR DESCRIPTION
# What

Remove ClearDB environment variable so the app won't try to access it. In Heroku settings, set the MYSQL_DATABASE_URL environment variable to the AWS database. 
# Why

ClearDB has limited space, and AWS will allow us to store much more data.
# Test

To test locally, manually set db_url in models.py to AWS MySQL url (can be found in Heroku settings) and run app.
